### PR TITLE
Agregar hoja de estilos desde rama de Jonathan

### DIFF
--- a/Comunidad_Conectada_Codigo/css/estilos_comunes.css
+++ b/Comunidad_Conectada_Codigo/css/estilos_comunes.css
@@ -1,0 +1,111 @@
+
+/* === Google Fonts === */
+@import url('https://fonts.googleapis.com/css2?family=Open+Sans&family=Poppins:wght@300;400;600;700&display=swap');
+
+/* === Reset básico === */
+* {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+/* === Variables de color === */
+/* Azul oscuro: #1E3A8A - encabezados, botones principales, menú */
+/* Azul claro:  #60A5FA - hover, íconos activos */
+/* Blanco:      #FFFFFF - fondo principal de tarjetas */
+/* Gris claro:  #F3F4F6 - fondos secundarios, formularios */
+/* Negro:       #111827 - texto principal */
+
+/* === Estilos globales === */
+body {
+  font-family: 'Poppins', sans-serif;
+  background-color: #F3F4F6;
+  color: #111827;
+  line-height: 1.6;
+}
+
+/* === Encabezado (Header) === */
+header {
+  background-color: #1E3A8A;
+  color: white;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 15px 30px;
+}
+
+/* === Botón genérico === */
+button {
+  background-color: #1E3A8A;
+  color: white;
+  padding: 8px 16px;
+  border: none;
+  border-radius: 5px;
+  font-family: 'Poppins', sans-serif;
+  font-size: 14px;
+  cursor: pointer;
+  transition: background-color 0.3s ease;
+}
+
+button:hover {
+  background-color: #60A5FA;
+}
+
+/* === Contenedor principal === */
+main {
+  padding: 30px;
+}
+
+/* === Footer === */
+footer {
+  background-color: #1E3A8A;
+  color: white;
+  text-align: center;
+  padding: 15px;
+  font-size: 14px;
+}
+
+/* === Tarjetas reutilizables === */
+.card {
+  background-color: #FFFFFF;
+  border-radius: 8px;
+  box-shadow: 0 4px 6px rgba(0,0,0,0.1);
+  padding: 20px;
+  text-align: center;
+  transition: transform 0.2s ease-in-out;
+}
+
+.card:hover {
+  transform: translateY(-5px);
+}
+
+.card h2 {
+  font-size: 20px;
+  font-weight: 600;
+  margin-bottom: 10px;
+}
+
+.card p {
+  font-size: 14px;
+  color: #555;
+  margin-bottom: 15px;
+}
+
+/* === Grid para tarjetas === */
+.tarjetas {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 20px;
+}
+
+/* === Responsive básico === */
+@media screen and (max-width: 768px) {
+  header {
+    flex-direction: column;
+    text-align: center;
+  }
+
+  .tarjetas {
+    grid-template-columns: 1fr;
+  }
+}


### PR DESCRIPTION
Se agregó el archivo estilos_comunes.css dentro de la carpeta /css. Este archivo contiene las reglas base para colores, fuentes, botones, tarjetas y responsividad. Todas las páginas podrán usarlo con un solo enlace.
